### PR TITLE
Replace @types/es6-shim with es6-shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/jellyjs/angular2-file-drop#readme",
   "dependencies": {
-    "@types/es6-shim": "^0.31.32",
+    "es6-shim": "^0.35.3",
     "fileapi": "^2.0.20"
   },
   "devDependencies": {


### PR DESCRIPTION
Replaces [@types/es6-shim](https://www.npmjs.com/package/@types/es6-shim) with [es6-shim](https://www.npmjs.com/package/es6-shim) library. The main reason is that it is better maintained. I'd like to ask @barbatus to check this change as well, as he was the one to introduce AOT to angular2-file-drop.

If it's OK, I'd like to urge @kamilkisiela to release this patch as soon as possible, as it is quite needed. Thanks!