### PR TITLE
Replace @types/es6-shim with compiler.lib option

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/jellyjs/angular2-file-drop#readme",
   "dependencies": {
-    "@types/es6-shim": "^0.31.32",
     "fileapi": "^2.0.20"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": false,
-    "types": ["@types/es6-shim"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "lib": ["es2015"]
   },
   "files": [
     "./src/index.ts",


### PR DESCRIPTION
Replaces: Using [@types/es6-shim library](https://www.npmjs.com/package/@types/es6-shim) with additional compiler.lib configuration in tsconfig.json.